### PR TITLE
Fix log rotation, ensure we only keep a small set

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,7 +13,9 @@ if (!fs.existsSync(logDir)) {
 
 const dailyRotateFileTransport = new transports.DailyRotateFile({
   filename: `${logDir}/%DATE%-results.log`,
-  datePattern: 'YYYY-MM-DD'
+  datePattern: 'YYYY-MM-DD',
+  maxSize: '5m',
+  maxFiles: '10'
 });
 
 function getEnvSensitiveFormatting () {


### PR DESCRIPTION
When I setup the log file rotation originally, I left off the options to remove the files and set a max.