### PR TITLE
Publish total lag per topic for each app on the main menu

### DIFF
--- a/lib/content_generator.js
+++ b/lib/content_generator.js
@@ -1,5 +1,6 @@
 const log = require('./logger');
 const transform = require('./transform_to_chart');
+const lagSummary = require('./lag_summary');
 let fs = require('fs');
 let _ = require('lodash');
 let moment = require('moment');
@@ -124,34 +125,71 @@ function indexPageTemplate (apps) {
   </script>
   </head>
   <body>
-    <div class="container">
+    <div class="container-fluid">
     ${navBarTemplate()}
-    <div class="row">
-        <div class="col">
-          ${apps}
-        </div>
-      </div>
+    ${apps}
     </div>
   </body>
   </html>  
     `;
 }
 
-function generateListItems (apps) {
-  return _.map(apps, (app) => {
-    return `
-    <button type="button" class="btn btn-primary btn-lg" 
-      onclick="location.href='charts/${app}.htm'">${app}</button>\n`;
-  }).join('');
+function buttonTemplate (app) {
+  return `<button type="button" class="btn btn-primary btn-lg" 
+    onclick="location.href='charts/${app}.htm'">${app}</button>\n`;
 }
 
-function generateMainMenu () {
-  let consumerGroups = consumerList.map(consumer => consumer.groupName);
-  let appRows = _.chunk(consumerGroups, 4);
-  return _.map(appRows, (apps) => {
-    return '<div class="row menuRow"><div class="col">' +
-    generateListItems(apps) +
-    '</div></div>';
+function rowTemplate (content) {
+  return `<div class="row-fluid menuRow">${content}</div>`;
+}
+
+function columnTemplate (content, width) {
+  if (!width) {
+    width = 6;
+  }
+  return `<div class="span${width}">${content}</div>`;
+}
+
+function badgeTypeClass (lagNumber) {
+  if (lagNumber === 0) {
+    return 'success';
+  } else if (lagNumber < 10000) {
+    return 'info';
+  } else if (lagNumber > 10000) {
+    return 'warning';
+  } else if (lagNumber > 100000) {
+    return 'important';
+  }
+}
+
+function badgeTemplate (lagNumber) {
+  if (isNaN(lagNumber)) {
+    lagNumber = 0;
+  }
+  let badgeType = badgeTypeClass(lagNumber);
+  return `<span class="badge badge-${badgeType}">${lagNumber}</span>`;
+}
+
+function generateMainMenu (lagRows) {
+  const summarizedLagItems = lagSummary.logTotalLagForTopicByApp(lagRows);
+  let lagByConsumer = _.groupBy(summarizedLagItems, 'consumerName');
+  // FIXME another undefined issue. fix it by hack for now
+  delete lagByConsumer.undefined;
+  return Object.keys(lagByConsumer).map(consumerName => {
+    let button = buttonTemplate(consumerName);
+    let consumerLag = lagByConsumer[consumerName];
+    // try to split lag into columns
+    let numberPerColumn = 2;
+    let consumerLagRows = _.chunk(consumerLag, numberPerColumn);
+    let consumerRow = consumerLagRows.map(lagRows => {
+      let cols = lagRows.map(lag => {
+        const badge = badgeTemplate(lag.TOTAL_TOPIC_LAG);
+        const topicColumn = columnTemplate(`${lag.TOPIC} ${badge}`);
+        return topicColumn;
+      }).join('');
+      return rowTemplate(cols);
+    }).join('');
+    return rowTemplate(`${columnTemplate(button)}${consumerRow}`);
   }).join('');
 }
 
@@ -164,7 +202,7 @@ function topicsForApp (lagForApp) {
 }
 
 function generatePages (lagRows) {
-  let htmlItems = generateMainMenu();
+  let htmlItems = generateMainMenu(lagRows);
   let indexPageContent = indexPageTemplate(htmlItems);
   generatePage('index', 'public', indexPageContent);
 

--- a/lib/save_lag.js
+++ b/lib/save_lag.js
@@ -5,7 +5,6 @@ const contentGenerator = require('./content_generator');
 let moment = require('moment');
 const settings = require('./settings');
 let dataStoreDir = settings['lag.files.dir'];
-const lagSummary = require('./lag_summary');
 
 function removeOldLagFiles () {
   fileUtils.deleteExpiredDatastoreFiles();
@@ -39,7 +38,6 @@ function saveToDataStore (lagItems) {
 // parse and feed it some data
 function processLagResults (lagData) {
   lagParser.parse(lagData, (lagItems) => {
-    lagSummary.logTotalLagForTopicByApp(lagItems);
     saveToDataStore(lagItems);
   });
 


### PR DESCRIPTION
This change publishes total lag per topic for each app on the main menu.
I'm not too happy about the CSS here but it works.
I'll probably start up a new issue to make the main menu prettier. 

Addresses https://github.com/mrjabba/lag-collector/issues/43